### PR TITLE
Added support for Sublime Text v2.

### DIFF
--- a/i_opener.py
+++ b/i_opener.py
@@ -5,7 +5,7 @@
 # Written by Ross Hemsley, 2013.
 #------------------------------------------------------------------------------#
 import sublime, sublime_plugin, time
-from os.path import isdir, isfile, expanduser, split, relpath, join, commonprefix, normpath, isabs
+from os.path import isdir, isfile, expanduser, split, relpath, join, commonprefix, normpath
 from os      import listdir, sep, makedirs
 
 # Locations of settings files.
@@ -29,6 +29,18 @@ def load_settings():
     HISTORY_ENTRIES = settings.get('history_entries')
 
 #------------------------------------------------------------------------------#
+# Set which version of Sublime Text has called the plugin.
+
+def set_sublime_text_version():
+    global SUBLIME_VERSION
+
+    sub_ver = int(sublime.version())
+
+    if   sub_ver >= 2000 and sub_ver <= 2999: SUBLIME_VERSION = 2
+    elif sub_ver >= 3000 and sub_ver <= 3999: SUBLIME_VERSION = 3
+    else:                                     SUBLIME_VERSION = 0
+
+#------------------------------------------------------------------------------#
 # Function to find and return longest possile completion for a path p from a
 # list of candidates l. Returns new_path, status, completed.
 
@@ -38,17 +50,17 @@ def get_completion(path):
 
     # Dir doesn't exist
     if not isdir(expanduser(directory)):
-        status    = "No match"  
+        status    = "No match"
         completed = False
         return path, status, completed
 
     # Get all matching files relating to this path.
     f_list = listdir(expanduser(directory))
-    
+
     matches  = []
 
-    # Case sensitivity test. 
-    if CASE_SENSITIVE:        
+    # Case sensitivity test.
+    if CASE_SENSITIVE:
         matches = [ f for f in f_list if f.startswith(filename) ]
     else:
         matches = [ f for f in f_list if f.lower().startswith(filename.lower())]
@@ -59,46 +71,39 @@ def get_completion(path):
     if len(matches) >  1:
         # We can do this more efficiently later.
         # Get the longest prefix, ignoring case.
-        prefix_length = len( commonprefix([ s.lower() for s in matches ]) )        
-        new_filename  = filename + matches[0][len(filename):prefix_length] 
+        prefix_length = len( commonprefix([ s.lower() for s in matches ]) )
+        new_filename  = filename + matches[0][len(filename):prefix_length]
         status        = "Complete, but not unique"
         completed     = False
-    elif len(matches) == 1:  
+    elif len(matches) == 1:
         new_filename  = matches[0]
         # If we completed a directory
         if isdir(expanduser(join(directory, new_filename))):
             new_filename += sep
         status        = None
-        completed     = True        
+        completed     = True
     else:
         new_filename  = filename
         status        = "No match"
         completed     = False
 
     return join(directory, new_filename), status, completed
-    
+
 #------------------------------------------------------------------------------#
 # Try to give a sensible estimate for 'current directory'.
-# If there is a single folder open, we return that. 
-# Else, if there is an active file, return its path. 
+# If there is a single folder open, we return that.
+# Else, if there is an active file, return its path.
 # If all else fails, return the home directory.
 
 def get_current_path():
-    home = expanduser("~")
-    view = sublime.active_window().active_view()
-    data = sublime.active_window().project_data()
-    here = None
+    home    = expanduser("~")
+    view    = sublime.active_window().active_view()
+    folders = sublime.active_window().folders()
+    here    = None
 
-    if USE_PROJECT_DIR and data and "folders" in data and len(data["folders"]) == 1:
-        specified_path = data["folders"][0]["path"]
-        if isabs(specified_path):
-            here = specified_path+sep
-        else:
-            project_file_name = sublime.active_window().project_file_name()
-            project_file_dir = split(project_file_name)[0]
-            here = normpath(join(project_file_dir, specified_path))+sep
-
-    elif view != None and view.file_name() != None:        
+    if USE_PROJECT_DIR and len(folders) == 1:
+        here = folders[0] + sep
+    elif view != None and view.file_name() != None:
         here = split(view.file_name())[0]
         if here != sep: here += sep
     else:
@@ -120,11 +125,15 @@ def get_current_path():
 # it when the panel is closed.
 #------------------------------------------------------------------------------#
 
+# Suggest renaming 'Path_input' to 'iOpenerPathInput' so that its name follows
+# the same naming convention used by ALL the other class names. </END OCD>
+
+# class iOpenerPathInput():
 class Path_input():
-    
+
     #----------------------------------------------------------------------#
     # Class initialisation.
-    
+
     def __init__(self):
         # If the user presses tab, and nothing happens, remember it.
         # If they press tab again, we show them a list of files.
@@ -135,16 +144,16 @@ class Path_input():
 
         # We only reload the history each time the input window is opened.
         self.history_cache = self.get_history()[0]
-        
+
         # Store default at end of history cache and 'select' it.
-        self.history_cache.append(path)        
+        self.history_cache.append(path)
         self.history_index = len(self.history_cache)-1
 
         self.view          = active_window.show_input_panel(
-            "Find file: ", 
-            path, 
-            self.open_file, 
-            self.update, 
+            "Find file: ",
+            path,
+            self.open_file,
+            self.update,
             self.cancel
         )
 
@@ -152,7 +161,7 @@ class Path_input():
     # If the user updates the input, reset the 'failed completion' flag.
 
     def update(self,text):
-        self.last_completion_failed = False    
+        self.last_completion_failed = False
 
     #----------------------------------------------------------------------#
 
@@ -178,17 +187,17 @@ class Path_input():
 
     #----------------------------------------------------------------------#
 
-    def add_to_history(self,path):        
+    def add_to_history(self,path):
         file_history, history_settings = self.get_history()
 
-        # Trim the history to the correct length and add latest entry.        
+        # Trim the history to the correct length and add latest entry.
         if HISTORY_ENTRIES > 1:
             file_history = file_history[-HISTORY_ENTRIES+1:]
             file_history.append(path)
         elif HISTORY_ENTRIES == 1:
             file_history = [path]
         elif HISTORY_ENTRIES == 0:
-            file_history = []            
+            file_history = []
 
         # Save updated history.
         history_settings.set("file_history", file_history)
@@ -196,16 +205,16 @@ class Path_input():
 
     #----------------------------------------------------------------------#
 
-    def get_history(self):        
+    def get_history(self):
         history_settings = sublime.load_settings(HISTORY_FILE)
         file_history     = history_settings.get("file_history")
         # Trim history.
-        if not file_history: 
+        if not file_history:
             file_history = []
         else:
             file_history = file_history[ -HISTORY_ENTRIES :]
-        return file_history, history_settings        
-    
+        return file_history, history_settings
+
     #----------------------------------------------------------------------#
     # Method called when we exit from the input panel without opening a file.
 
@@ -218,19 +227,19 @@ class Path_input():
 
     def get_text(self):
         return self.view.substr(sublime.Region(0, self.view.size()))
-    
+
     #----------------------------------------------------------------------#
     # Open the given path. Can be a directory OR a file.
 
     def open_file(self, path):
-        self.add_to_history(path)
-
         path = expanduser(path)
 
         # Ignore empty paths.
-        if len(path) == 0: 
+        if len(path) == 0:
             sublime.status_message("Warning: Ignoring empty path.")
             return
+
+        self.add_to_history(path)
 
         directory = ""
         filename  = ""
@@ -254,7 +263,11 @@ class Path_input():
                     )
                     return
 
-        if filename == "":
+        if isdir(path):
+            # Project folders can not be added using the ST2 API.
+            if SUBLIME_VERSION == 2:
+                sublime.status_message("Warning: Opening folders requires ST v3.")
+                return
             project_data = sublime.active_window().project_data();
             if OPEN_FOLDERS_IN_NEW_WINDOW:
                 # Open directory in a new window (mirror behaviour of ST).
@@ -295,9 +308,9 @@ class Path_input():
     # Show a quick panel containing the possible completions.
 
     def show_completions(self):
-        active_window      = sublime.active_window()  
+        active_window      = sublime.active_window()
         directory,filename = split(self.get_text())
-        
+
         dir_list = listdir(expanduser(directory))
 
         if CASE_SENSITIVE:
@@ -305,7 +318,7 @@ class Path_input():
         else:
             f  = filename.lower()
             self.path_cache = [x for x in dir_list if x.lower().startswith(f)]
-        
+
         if len(self.path_cache) == 0:
             sublime.status_message("No match")
         else:
@@ -315,11 +328,11 @@ class Path_input():
 
     def on_done(self, i):
         if (self.path_cache == None):  return
-        
+
         if (i!=-1):
             # Remove what was there before.
             directory = split( self.get_text() )[0]
-            new_path  = join(directory, self.path_cache[i])            
+            new_path  = join(directory, self.path_cache[i])
             self.path_cache = None
 
             if (isdir(expanduser(new_path))):
@@ -331,6 +344,7 @@ class Path_input():
                 sublime.active_window().run_command("hide_panel", {"cancel": True})
         else:
             sublime.active_window().focus_view(self.view)
+
 
     #----------------------------------------------------------------------#
 
@@ -346,14 +360,13 @@ class Path_input():
 # need to know if the plugin is active. If so, Sublime Text calls the correct
 # commands.
 
-class iOpenerEventListener(sublime_plugin.EventListener):    
+class iOpenerEventListener(sublime_plugin.EventListener):
     def on_query_context(self, view, key, operator, operand, match_all):
-        return  (
-                 key                              ==  'i_opener'  
-            and  iOpenerCommand.input_panel       !=  None
-            and  iOpenerCommand.input_panel.view  ==  view
+        return (key                                   ==  'i_opener'
+            and iOpenerCommand.input_panel            !=  None
+            and iOpenerCommand.input_panel.view.id()  ==  view.id()
         )
-        
+
 #------------------------------------------------------------------------------#
 # The edit command used for editing the text in the input panel.
 
@@ -365,18 +378,18 @@ class iOpenerUpdateCommand(sublime_plugin.TextCommand):
 #------------------------------------------------------------------------------#
 # The command called by tapping tab in the open panel.
 
-class iOpenerCompleteCommand(sublime_plugin.WindowCommand):    
+class iOpenerCompleteCommand(sublime_plugin.WindowCommand):
 
     def run(self):
-        input_panel = iOpenerCommand.input_panel        
-        
+        input_panel = iOpenerCommand.input_panel
+
         if(input_panel.last_completion_failed):
             input_panel.last_completion_failed = False
 
             # Show the contents of this directory (if it exists).
             input_panel.show_completions()
         else:
-            # Do path completion.            
+            # Do path completion.
             path, status, complete = get_completion( input_panel.get_text() )
             if (status != None):
                 sublime.status_message(status)
@@ -400,6 +413,13 @@ class iOpenerCommand(sublime_plugin.WindowCommand):
     input_panel  = None
 
     def run(self):
+
+        # Set the ST version and check in case of ancient/future versions.
+        set_sublime_text_version()
+        if SUBLIME_VERSION != 2 and SUBLIME_VERSION != 3:
+            print("iOpener plugin is only for Sublime Text v2 and v3.")
+            return
+
         # Re-load the settings file, which may have changed since last run.
         load_settings()
 


### PR DESCRIPTION
I've modified `i_opener.py` so that it now works with Sublime Text v2. It has been tested with the latest release versions of both ST2 and ST3 on both Linux (64 bit) and Windows XP (32 bit) and is working well.

Please note that I use the ST setting `trim_trailing_white_space_on_save`. When I did a `git diff` with the last commit, dozens of lines were shown as changed when they had not been and I realized they must have had trailing whitespace. Ignore these with the `git diff --ignore-space-at-eol` option (regular diff uses `-Z` to do the same thing). I can't seem to find any way to tell github to ignore trailing whitespace in the diff on the pull request page.


### List of changes made in branch `st2_support`:


1) Added the `set_sublime_text_version()` function and a ST version check in the `iOpenerCommand` class.

2) Changed the `get_current_path()` method to use the ST window class method `folders()` instead of `project_data()` to get the project's folders (if any). `folders()` always provides the full path to project folders so the code to build the full path is no longer necessary. It returns an empty list if there is no open project or if an open project has no folders set. `project_data()` is only in the ST3 API, while `folders()` is in both the ST2 and ST3 APIs.

3) Removed the `os.path import` of `isabs()`; it is no longer needed due to 2).

4) Changed the `on_query_context()` method in the `iOpenerEventListener` class.

Instead of directly comparing the view objects, it now compares the view objects' ids. i.e.

    Was: iOpenerCommand.input_panel.view == view
    Now: iOpenerCommand.input_panel.view.id() == view.id()

This was done for compatibility with ST2 because the view object comparison always failed. It took me a while to work out why it was failing but, by inspecting the view class of both APIs, I discovered that the view class in the ST3 API has the *special* methods `__eq__` and `__ne__`, which facilitate object comparison tests using `==` and `!=`, while the view class in the ST2 API does not have them. `view.id()` returns an integer which uniquely identifies the view, using this for the comparison works well with both ST2 and ST3 and is a suitable alternative to directly comparing the objects.

5) Several changes to the `open_file()` method in the `Path_input` class:

a) Fixed a minor *bug* by moving the call to `add_to_history()` below the check for empty paths, so that empty paths no longer get added to the history. The *bug* can be reproduced by opening an empty path and then scrolling up in the history.

b) If the user enters the path to a folder, the plugin adds that folder to the project folder list (in a new window by default). Project data can not be set using the ST2 API so this feature is incompatible with ST2. A check has been added to see if ST2 is running before trying to add a project folder, if it is then a status message is displayed saying that opening folders requires ST3 and the method returns.

c) Fixed a minor *bug* that allows users to create a new buffer with the same full path as an existing folder, they would never be able to save the file. The *bug* can be reproduced by opening a buffer with the same full path as an existing folder but without a trailing slash. It was fixed by changing the `if filename == "":` line to `if isdir(path):` which in ST3 *opens the folder* even if the path is missing the trailing slash, while ST2 users get the status message saying that opening folders requires ST3 as described in b).

Finally: It took great strength to resist changing the name of the `Path_input` class to `iOpenerPathInput` so that the class names all follow the same naming convention; but recognizing that it's a little OCD of me I left if for you to do so if you wish. [Actually I did change it but changed it back again after recognizing that it wasn't my place to do so.]

I hope this helps. All the best, mattst
