### PR TITLE
dev-mattst branch; ST2 support fixed and new folder list scrolling feature

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,30 +1,48 @@
 [
     // Steal open command and use it for iOpener.
     { "keys": ["ctrl+o"], "command": "i_opener" },
-    
+
     // Allow over-riding of iOpener, and show normal system dialog.
-    { "keys": ["ctrl+shift+o"], "command": "prompt_open_file" },  
+    { "keys": ["ctrl+shift+o"], "command": "prompt_open_file" },
 
+    // Be especially careful editing the settings below.
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Do not edit //
-    ////////////////////////////////////////////////////////////////////////////
+    // Auto-complete path key.
     {
         "keys": ["tab"],
         "command": "i_opener_complete",
         "context": [{"key": "i_opener"}]
     },
+
+    // Scroll up through history.
     {
         "keys": ["up"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "up"}
     },
+
+    // Scroll down through history.
     {
         "keys": ["down"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "down"}
+    },
+
+    // Scroll up through folder list.
+    {
+        "keys": ["ctrl+up"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "up"}
+    },
+
+    // Scroll down through folder list.
+    {
+        "keys": ["ctrl+down"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "down"}
     }
-    ////////////////////////////////////////////////////////////////////////////
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -35,7 +35,7 @@
         "keys": ["ctrl+up"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "up"}
+        "args": {"operation": "scroll_up"}
     },
 
     // Scroll down through folder list.
@@ -43,6 +43,46 @@
         "keys": ["ctrl+down"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "down"}
+        "args": {"operation": "scroll_down"}
+    },
+
+    // Show user's Home folder.
+    {
+        "keys": ["ctrl+h"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_home_folder"}
+    },
+
+    // Show the folder of the current File.
+    {
+        "keys": ["ctrl+f"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_file_folder"}
+    },
+
+    // Show the current Project folders.
+    {
+        "keys": ["ctrl+p"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_project_folders"}
+    },
+
+    // Show the User defined folders; set by the "folders" setting.
+    {
+        "keys": ["ctrl+u"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_user_folders"}
+    },
+
+    // Show All the folders; set by the "folder_sequence" setting.
+    {
+        "keys": ["ctrl+a"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_folder_sequence_folders"}
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -35,7 +35,7 @@
         "keys": ["super+up"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "up"}
+        "args": {"operation": "scroll_up"}
     },
 
     // Scroll down through folder list.
@@ -43,6 +43,46 @@
         "keys": ["super+down"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "down"}
+        "args": {"operation": "scroll_down"}
+    },
+
+    // Show user's Home folder.
+    {
+        "keys": ["super+h"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_home_folder"}
+    },
+
+    // Show the folder of the current File.
+    {
+        "keys": ["super+f"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_file_folder"}
+    },
+
+    // Show the current Project folders.
+    {
+        "keys": ["super+p"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_project_folders"}
+    },
+
+    // Show the User defined folders; set by the "folders" setting.
+    {
+        "keys": ["super+u"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_user_folders"}
+    },
+
+    // Show All the folders; set by the "folder_sequence" setting.
+    {
+        "keys": ["super+a"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_folder_sequence_folders"}
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,30 +1,48 @@
 [
     // Steal open command and use it for iOpener.
     { "keys": ["super+o"], "command": "i_opener" },
-    
+
     // Allow over-riding of iOpener, and show normal system dialog.
-    { "keys": ["super+shift+o"], "command": "prompt_open_file" },    
+    { "keys": ["super+shift+o"], "command": "prompt_open_file" },
 
+    // Be especially careful editing the settings below.
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Do not edit //
-    ////////////////////////////////////////////////////////////////////////////
+    // Auto-complete path key.
     {
         "keys": ["tab"],
         "command": "i_opener_complete",
         "context": [{"key": "i_opener"}]
     },
+
+    // Scroll up through history.
     {
         "keys": ["up"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "up"}
     },
+
+    // Scroll down through history.
     {
         "keys": ["down"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "down"}
+    },
+
+    // Scroll up through folder list.
+    {
+        "keys": ["super+up"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "up"}
+    },
+
+    // Scroll down through folder list.
+    {
+        "keys": ["super+down"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "down"}
     }
-    ////////////////////////////////////////////////////////////////////////////
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -35,7 +35,7 @@
         "keys": ["ctrl+up"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "up"}
+        "args": {"operation": "scroll_up"}
     },
 
     // Scroll down through folder list.
@@ -43,6 +43,46 @@
         "keys": ["ctrl+down"],
         "command": "i_opener_folder_list",
         "context": [{"key": "i_opener"}],
-        "args": {"direction": "down"}
+        "args": {"operation": "scroll_down"}
+    },
+
+    // Show user's Home folder.
+    {
+        "keys": ["ctrl+h"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_home_folder"}
+    },
+
+    // Show the folder of the current File.
+    {
+        "keys": ["ctrl+f"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_file_folder"}
+    },
+
+    // Show the current Project folders.
+    {
+        "keys": ["ctrl+p"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_project_folders"}
+    },
+
+    // Show the User defined folders; set by the "folders" setting.
+    {
+        "keys": ["ctrl+u"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_user_folders"}
+    },
+
+    // Show All the folders; set by the "folder_sequence" setting.
+    {
+        "keys": ["ctrl+a"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"operation": "show_folder_sequence_folders"}
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,30 +1,48 @@
 [
     // Steal open command and use it for iOpener.
     { "keys": ["ctrl+o"], "command": "i_opener" },
-    
-    // Allow over-riding of iOpener, and show normal system dialog.
-    { "keys": ["ctrl+shift+o"], "command": "prompt_open_file" },  
 
-    
-    ////////////////////////////////////////////////////////////////////////////
-    // Do not edit //
-    ////////////////////////////////////////////////////////////////////////////
+    // Allow over-riding of iOpener, and show normal system dialog.
+    { "keys": ["ctrl+shift+o"], "command": "prompt_open_file" },
+
+    // Be especially careful editing the settings below.
+
+    // Auto-complete path key.
     {
         "keys": ["tab"],
         "command": "i_opener_complete",
         "context": [{"key": "i_opener"}]
     },
+
+    // Scroll up through history.
     {
         "keys": ["up"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "up"}
     },
+
+    // Scroll down through history.
     {
         "keys": ["down"],
         "command": "i_opener_cycle_history",
         "context": [{"key": "i_opener"}],
         "args": {"direction": "down"}
+    },
+
+    // Scroll up through folder list.
+    {
+        "keys": ["ctrl+up"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "up"}
+    },
+
+    // Scroll down through folder list.
+    {
+        "keys": ["ctrl+down"],
+        "command": "i_opener_folder_list",
+        "context": [{"key": "i_opener"}],
+        "args": {"direction": "down"}
     }
-    ////////////////////////////////////////////////////////////////////////////
 ]

--- a/i_opener.py
+++ b/i_opener.py
@@ -8,9 +8,19 @@ Written by Ross Hemsley and other collaborators 2013.
 import sublime, sublime_plugin, time
 from os.path import isdir, isfile, expanduser, split, relpath, join, commonprefix, normpath
 from os      import listdir, sep, makedirs
+from sys     import version_info
 
-from .matching import complete_path, COMPLETION_TYPE, get_matches
-from .paths import get_current_directory, directory_listing_with_slahes
+# Version specific import. Note sure if this is required due to differences in
+# the way ST v2 and v3 load packages or due to the different Python versions.
+# Note: Do not use the 'major' attribute, Python v2.7+ only, ST2 uses v2.6.
+python_version_major = version_info[0]
+
+if python_version_major == 3:
+    from .matching import complete_path, COMPLETION_TYPE, get_matches
+    from .paths import get_current_directory, directory_listing_with_slahes
+elif python_version_major == 2:
+    from matching import complete_path, COMPLETION_TYPE, get_matches
+    from paths import get_current_directory, directory_listing_with_slahes
 
 # Locations of settings files.
 HISTORY_FILE     = 'i_opener_history.sublime-settings'

--- a/i_opener.sublime-settings
+++ b/i_opener.sublime-settings
@@ -1,7 +1,4 @@
 {
-    // Whether or not to consider the project's directory when choosing a path at which to start
-    "use_project_dir": false,
-
     // Whether to open folders in a new window or add them to the project in the current window
     "open_folders_in_new_window": true,
 
@@ -9,5 +6,39 @@
     "case_sensitive": false,
 
     // Number of entries to store in history.
-    "history_entries": 30
+    "history_entries": 30,
+
+    // "folder_sequence" sets which folders will be added to the folder list and the order those
+    // folders will be displayed in when scrolling through the folder list. Each folder will be
+    // added only once, the first time it is encountered.
+    //
+    // Possible values; use any or all of the following and in any order you want:
+    //
+    // "home"    : user's home folder.
+    // "file"    : folder of the current file (if there is one).
+    // "project" : folders added to the current project (if any).
+    // "user"    : folders added to the "folders" entry in this file (if any).
+    //
+    // e.g.
+    // "folder_sequence": ["home", "file", "project", "user"],
+
+    "folder_sequence": ["home", "file", "project", "user"],
+
+    // "folders" sets which folders to add to the folder list when "user" is entered in the
+    // "folder_sequence". Use the full path or the home prefix and add as many as you want.
+    //
+    // e.g.
+    // "folders":
+    // [
+    //     "~/Path/To/Folder/In/Home/",
+    //     "/Full/Path/To/Folder/"
+    //
+    //     In Windows the backslashes must be escaped.
+    //     "~\\Path\\To\\Folder\\In\\Home\\",
+    //     "c:\\Full\\Path\\To\\Folder\\"
+    // ],
+
+    "folders":
+    [
+    ]
 }

--- a/i_opener.sublime-settings
+++ b/i_opener.sublime-settings
@@ -25,7 +25,8 @@
     "folder_sequence": ["home", "file", "project", "user"],
 
     // "folders" sets which folders to add to the folder list when "user" is entered in the
-    // "folder_sequence". Use the full path or the home prefix and add as many as you want.
+    // "folder_sequence" or when the 'user folders' key binding is pressed. Use the full path
+    // or the home prefix and add as many as you want.
     //
     // e.g.
     // "folders":

--- a/paths.py
+++ b/paths.py
@@ -20,24 +20,8 @@ def directory_listing_with_slahes(path):
     return output
 
 
-def get_current_directory(view_filename, folders, use_project_dir):
-    """
-    Try to give a sensible estimate for 'current directory'.
-    If there is a single folder open, we return that.
-    Else, if there is an active file, return its path.
-    If all else fails, return the home directory.
-    """
-    if folders and use_project_dir:
-        directory = folders[0]
-    elif view_filename is not None:
-        directory, _ = split(view_filename)
-    else:
-        directory = HOME_DIRECTORY
-
-    if directory != sep:
-        directory += sep
-
-    return get_path_relative_to_home(directory)
+def get_path_to_home():
+    return HOME_DIRECTORY + sep
 
 
 def get_path_relative_to_home(path):
@@ -49,5 +33,9 @@ def get_path_relative_to_home(path):
             return join(HOME_DIRECTORY, relpath(path, home)) + sep
         else:
             return HOME_DIRECTORY + sep
-    else:
+
+    elif path.endswith(sep):
         return path
+
+    else:
+        return path + sep


### PR DESCRIPTION
Hi there,

There is a minor change and a major change.

- Minor: Fixed broken ST v2 support. It was broken by the switch to the more modular design and fixed by doing a version specific import of the `paths` and `matching` modules.
- Major: New folder list scrolling feature.

The folder list scrolling is similar to the history scrolling feature. A folder list is created from the following possible locations: the user's home folder, the folder of the current file, the project folders, and additional user set folders which can be added in the settings file. The order the folders appear in can be controlled by the user in the `i_opener.sublime-settings` with the `folder_sequence` setting, and the user's additional folders can be set with the `folders` setting.

    // `i_opener.sublime-settings`:

    // User control of what order to add the folders in.
    "folder_sequence": ["home", "file", "project", "user"],

    // User set folders to add.
    "folders":
    [
         "~/Path/To/Folder/In/Home/",
         "/Full/Path/To/Folder/"
    ]

The `i_opener.sublime-settings` file has detailed instructions.

Moving up and down the folder list is almost identical to the history feature except that a modifier key is used. `ctrl+up/down` for Linux/Windows, `super+up/down` for OSX.

In addition users can change to different folders and folder lists using key bindings.

- `ctrl+h` - display the home folder.
- `ctrl+f` - display the folder of current file.
- `ctrl+p` - load project folders, display the first one, and allow scrolling through them.
- `ctrl+u` - load the user defined folders from the settings file, display the first one, and allow scrolling through them.
- `ctrl+a` - load the folders list created using `folder_sequence` setting, display the first one, and allow scrolling through them. This is the initial folder list when the plugin starts.
- OSX uses `super` in place of `ctrl`.

This feature has made both the `get_current_directory()` function and the `use_project_dir` setting redundant; both have been removed.

Tested and working with ST v3 and v2 on both Linux and Windows XP. Completely untested on OSX, you wouldn't happen to be an OSX user would you?

A few other minor changes were made; e.g. a few typos, comments, a variable or two renamed, and the check for ST v2 or v3 in `iOpenerCommand` is now set to the positive rather than the negative, in keeping with good practice.

I hope this meets with your approval.
