### PR TITLE
Fix bug, when adding a folder to a "blank" project

### DIFF
--- a/i_opener.py
+++ b/i_opener.py
@@ -208,7 +208,11 @@ class iOpenerPathInput():
                 project_folders = project_data.get('folders') or []
 
                 folder = dict(path=path, follow_symlinks=True, folder_exclude_patterns=['.*'])
-                if all(folder['path'] != path for folder in project_folders):
+
+                # if project_data == {}, no project is open.
+                if project_data == {}:
+                    project_data = dict(folders=[dict(follow_symlinks=True, path=path)])
+                elif all(folder['path'] != path for folder in project_folders):
                     project_data['folders'].append(folder)
                 sublime.active_window().set_project_data(project_data)
         else:


### PR DESCRIPTION
if the setting:  
`"open_folders_in_new_window": false,`  

Is set to false and one tries to open a directory on a *"blank"* (after a project has been closed) workspace, nothing happens.

With this patch, the selected folder will be added to a new project. (just as when the setting above is set to true, with the difference that it will use the currently open window)